### PR TITLE
implement info() method on hasher

### DIFF
--- a/src/Hashing/TrinityCoreHasher.php
+++ b/src/Hashing/TrinityCoreHasher.php
@@ -61,4 +61,15 @@ class TrinityCoreHasher implements IlluminateHasher
     public function needsRehash($hashedValue, array $options = array()) {
         return false;
     }
+    
+    /**
+     * Get information about the given hashed value.
+     *
+     * @param  string $hashedValue
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        // TODO: Implement info() method.
+    }
 }


### PR DESCRIPTION
Laravel 5.6.17 updates the hasher interface with an info method. Stubbing it out satisfies the implementation

REF: https://github.com/laravel/framework/commit/d7395d7d8b279fbd25fd83bcc92d5114e637b6a9