### PR TITLE
Add support for Laravel 5.5 package auto-discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,15 @@
         "psr-4": {
             "ThibaudDT\\TrinityCoreAuth\\": "src/"
         }
+    },
+    "extra": {
+    "laravel": {
+      "providers": [
+        "ThibaudDT\\TrinityCoreAuth\\Providers\\TrinityCoreAuthServiceProvider"
+      ],
+      "aliases": {
+        "ThibaudDT": "Flashadvocate\\TrinityCoreAuth\\Facades\\TrinityCore"
+      }
     }
+  }
 }


### PR DESCRIPTION
Negates the need to add provider or alias to `config/app.php`