### PR TITLE
Allow to use custom Account model

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Configuration
 
 | Configuration | Value type | Default value | Description |
 | :-------------:|:-------------:| :-----:| :-----:|
-| passport | boolean | false | Active the support of Laravel Passport |
+| expansion | int | 7 | Server expansion |
 
 Usage
 =====
@@ -166,13 +166,6 @@ Usage
 ```
 TrinityCoreAuth::routes(); 
 ```
-
-FAQ
-=====
-* Can I active the support of Laravel Passport before a first installation without ?
-
-Yes you can ! Change the configuration value to true and make a refresh of migrations. All accounts created before the 
-activation of the support of Laravel Passport must reset their password to use Password Grant Authorization system.
 
 Credits
 =======

--- a/config/config.php
+++ b/config/config.php
@@ -3,16 +3,15 @@
 return [
 
     /*
-      |--------------------------------------------------------------------------
-      | Support Laravel Passport
-      |--------------------------------------------------------------------------
-      |
-      | Set to true if you want support Laravel Passport authentication
-      |
-      | Think to refresh migrations to create new column for the support of Laravel Passport
-      |
-      */
-
-    'passport' => false,
+      0 = Classic
+      1 = The Burning Crusade (TBC)
+      2 = Wrath of the Lich King (WotLK)
+      3 = Cataclysm
+      4 = Mist of Pandaria (MOP)
+      5 = Warlords of Draenor (WOD)
+      6 = Legion
+      7 = Battle for Azeroth (BFA)
+    */
+    'expansion' => 7
 
 ];

--- a/database/migrations/2016_12_20_151524_alter_account_table.php
+++ b/database/migrations/2016_12_20_151524_alter_account_table.php
@@ -14,13 +14,8 @@ class AlterAccountTable extends Migration
     public function up()
     {
        Schema::connection('auth')->table('account', function ($table) {
-            if ( ! Schema::connection('auth')->hasColumn('account', 'remember_token')) {
+            if (!Schema::connection('auth')->hasColumn('account', 'remember_token'))
                 $table->string('remember_token', 100)->nullable();
-            }
-
-            if (config('trinitycore-auth.passport')) {
-                $table->string('password');
-            }
         });
     }
 
@@ -33,9 +28,6 @@ class AlterAccountTable extends Migration
     {
         Schema::connection('auth')->table('account', function ($table) {
             $table->dropColumn('remember_token');
-            if (Schema::connection('auth')->hasColumn('account', 'password')) {
-                $table->dropColumn('password');
-            }
         });
     }
 }

--- a/src/Hashing/TrinityCoreHasher.php
+++ b/src/Hashing/TrinityCoreHasher.php
@@ -23,19 +23,15 @@ class TrinityCoreHasher implements IlluminateHasher
      * @return string
      */
     public function make($data, array $options = array()) {
-        if(is_string($data)) {
-            if (config('trinitycore-auth.passport'))
-                return md5($data);
-            else
-                throw new \InvalidArgumentException("Cannot create password hash for TrinityCore with only one argument.");
-        }
         if(is_array($data))
         {
             // cast $user Array to Object, no need to instantiate a Collection here.
             $data = (object)$data;
         }
+        else
+            throw new \InvalidArgumentException('Cannot create password hash for TrinityCore with only one argument.');
 
-        return SHA1(strtoupper($data->username.':'.$data->password));
+        return strtoupper(bin2hex(strrev(hex2bin(strtoupper(hash('sha256',strtoupper(hash('sha256', strtoupper($data->username)).":".strtoupper($data->password))))))));
     }
 
     /**

--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -94,12 +94,8 @@ class RegisterController extends Controller
                 'password' => $data['password']
             ]),
             'reg_mail' => $data['email'],
-            'expansion' => 2
+            'expansion' => config('trinitycore-auth.expansion')
         ];
-
-        if(config('trinitycore-auth.passport')){
-            $account['password'] = md5($data['password']);
-        }
 
         return Account::create($account);
     }

--- a/src/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/Auth/ResetPasswordController.php
@@ -70,10 +70,6 @@ class ResetPasswordController extends Controller
             'remember_token' => Str::random(60),
         ];
 
-        if(config('trinitycore-auth.passport')){
-            $data['password'] = md5($password);
-        }
-
         $user->forceFill($data)->save();
     }
 

--- a/src/Models/Auth/Account.php
+++ b/src/Models/Auth/Account.php
@@ -34,12 +34,6 @@ class Account extends AccountTrinityCore implements
     function __construct(array $attributes = [])
     {
         $this->hidden[] ='remember_token';
-
-        if(config('trinitycore-auth.passport')){
-            $this->hidden[] ='password';
-            $this->fillable[] ='password';
-        }
-
         parent::__construct($attributes);
 
     }

--- a/src/Providers/AccountProvider.php
+++ b/src/Providers/AccountProvider.php
@@ -34,7 +34,7 @@ class AccountProvider extends EloquentUserProvider
     {
 
         $password = $credentials['password'];
-        $username = array_key_exists('username', $credentials) ? $credentials['username'] : $this->model->whereEmail($credentials['email'])->FirstOrFail()->username;
+        $username = array_key_exists('username', $credentials) ? $credentials['username'] : $this->model->whereEmail($credentials['email'])->FirstOrFail()->email;
 
         return $this->hasher->check(compact('username', 'password'), $user->getAuthPassword());
     }

--- a/src/Providers/TrinityCoreAuthServiceProvider.php
+++ b/src/Providers/TrinityCoreAuthServiceProvider.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\Hashing\Hasher as IlluminateHasher;
 use ThibaudDT\TrinityCoreAuth\Guard\TrinityCoreGuard;
 use ThibaudDT\TrinityCoreAuth\Hashing\TrinityCoreHasher;
 
-use ThibaudDT\TrinityCoreAuth\Models\Auth\Account;
 use ThibaudDT\TrinityCoreAuth\TrinityCore;
 
 /**
@@ -77,8 +76,8 @@ class TrinityCoreAuthServiceProvider extends ServiceProvider
      */
     protected function registerAuthProvider()
     {
-        Auth::provider('trinitycore', function (Application $app) {
-            return new AccountProvider($app->make(IlluminateHasher::class), $app->make(Account::class));
+        Auth::provider('trinitycore', function (Application $app, array $config) {
+            return new AccountProvider($app->make(IlluminateHasher::class), $app->make($config['model']));
         });
     }
 


### PR DESCRIPTION
Hi, thanks for your work!

I needed to load / extends my own Account Model.
I'm pretty new to Laravel but I think this should allow to do it (model specified in config/auth.php under providers). It seems to be working fine for me.

Hope it makes sense!